### PR TITLE
Fixed relative path on 'load_image' method

### DIFF
--- a/flappybird.py
+++ b/flappybird.py
@@ -269,7 +269,8 @@ def load_images():
         img_file_name: The file name (including its extension, e.g.
             '.png') of the required image, without a file path.
         """
-        file_name = os.path.join('.', 'images', img_file_name)
+        script_dir = os.path.dirname(__file__) #<-- absolute dir the script is in
+        file_name = os.path.join(script_dir, 'images', img_file_name)
         img = pygame.image.load(file_name)
         img.convert()
         return img


### PR DESCRIPTION
The relative path using "." was not working for me on Ubuntu 19.04, Python 3.7.2, throwing errors and not allowing me to launch the game.

This is a quick fix which is more compatible with different python versions.